### PR TITLE
Load LDtk levels and spawn player entity

### DIFF
--- a/assets/levels/lvl_01_test.json
+++ b/assets/levels/lvl_01_test.json
@@ -1,0 +1,32 @@
+{
+  "pxWid": 160,
+  "pxHei": 160,
+  "layerInstances": [
+    {
+      "__identifier": "Ground",
+      "__type": "IntGrid",
+      "gridSize": 32,
+      "intGridCsv": [
+        0,0,0,0,0,
+        0,0,0,0,0,
+        0,0,1,1,1,
+        0,0,1,1,1,
+        0,0,1,1,1
+      ],
+      "__cWid": 5,
+      "__cHei": 5
+    },
+    {
+      "__identifier": "Entities",
+      "__type": "Entities",
+      "entityInstances": [
+        {
+          "__identifier": "SpawnPoint",
+          "px": [32, 32],
+          "width": 16,
+          "height": 16
+        }
+      ]
+    }
+  ]
+}

--- a/assets/levels/test.ldtk
+++ b/assets/levels/test.ldtk
@@ -1,0 +1,1 @@
+{"dummy": true}

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -1,0 +1,29 @@
+import Phaser from 'phaser';
+import InputManager from '../systems/InputManager';
+
+export default class Player extends Phaser.Physics.Arcade.Sprite {
+  private input: InputManager;
+
+  constructor(scene: Phaser.Scene, x: number, y: number) {
+    super(scene, x, y, 'player');
+    scene.add.existing(this);
+    scene.physics.add.existing(this);
+    this.setBounce(0.1);
+    this.input = new InputManager(scene);
+  }
+
+  preUpdate(time: number, delta: number) {
+    super.preUpdate(time, delta);
+    const speed = 160;
+    if (this.input.left) {
+      this.setVelocityX(-speed);
+    } else if (this.input.right) {
+      this.setVelocityX(speed);
+    } else {
+      this.setVelocityX(0);
+    }
+    if (this.input.jump && this.body.blocked.down) {
+      this.setVelocityY(-330);
+    }
+  }
+}

--- a/src/scenes/Play.ts
+++ b/src/scenes/Play.ts
@@ -1,10 +1,9 @@
 import Phaser from 'phaser';
 import LDtkLoader from '../systems/LDtkLoader';
-import InputManager from '../systems/InputManager';
+import Player from '../entities/Player';
 
 export default class Play extends Phaser.Scene {
-  private player!: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
-  private inputManager!: InputManager;
+  private player!: Player;
 
   constructor() {
     super('Play');
@@ -12,37 +11,21 @@ export default class Play extends Phaser.Scene {
 
   create() {
     const loader = new LDtkLoader(this);
-    const level = loader.load('level1');
+    const { collisionLayer, entities } = loader.load('level1', {
+      SpawnPoint: Player
+    });
 
-    this.player = this.physics.add.sprite(100, 100, 'player');
-    this.player.setBounce(0.1);
+    this.player = entities.find((e) => e instanceof Player) as Player;
 
-    if (level.collisionLayer) {
-      this.physics.add.collider(this.player, level.collisionLayer);
+    if (collisionLayer) {
+      this.physics.add.collider(this.player, collisionLayer);
     }
 
     this.cameras.main.startFollow(this.player);
-
-    this.inputManager = new InputManager(this);
 
     // Hotkey to switch to Visual Novel scene
     this.input.keyboard.on('keydown-V', () => {
       this.scene.start('VisualNovel');
     });
-  }
-
-  update() {
-    const speed = 160;
-    if (this.inputManager.left) {
-      this.player.setVelocityX(-speed);
-    } else if (this.inputManager.right) {
-      this.player.setVelocityX(speed);
-    } else {
-      this.player.setVelocityX(0);
-    }
-
-    if (this.inputManager.jump && this.player.body.blocked.down) {
-      this.player.setVelocityY(-330);
-    }
   }
 }

--- a/src/scenes/Preload.ts
+++ b/src/scenes/Preload.ts
@@ -20,8 +20,8 @@ export default class Preload extends Phaser.Scene {
       'jump',
       'https://labs.phaser.io/assets/audio/SoundEffects/key.wav'
     );
-    // Placeholder LDtk level and ink story
-    this.load.json('level1', '/levels/placeholder.ldtk');
+    // LDtk level and ink story
+    this.load.json('level1', '/levels/lvl_01_test.json');
     this.load.json('inkTest', '/dialogue/sample.ink.json');
   }
 

--- a/src/systems/LDtkLoader.ts
+++ b/src/systems/LDtkLoader.ts
@@ -1,39 +1,69 @@
 import Phaser from 'phaser';
 
-interface SimpleLayer {
-  name: string;
-  data: number[][];
-  collides?: boolean;
+type EntityConstructor = new (scene: Phaser.Scene, x: number, y: number) => Phaser.GameObjects.GameObject;
+
+interface LDtkEntity {
+  __identifier: string;
+  px: [number, number];
 }
 
-interface SimpleLDtk {
-  tileSize: number;
-  width: number;
-  height: number;
-  layers: SimpleLayer[];
+interface LDtkLayer {
+  __identifier: string;
+  __type: string;
+  gridSize?: number;
+  intGridCsv?: number[];
+  __cWid?: number;
+  __cHei?: number;
+  entityInstances?: LDtkEntity[];
+}
+
+interface LDtkLevel {
+  pxWid: number;
+  pxHei: number;
+  layerInstances: LDtkLayer[];
 }
 
 export default class LDtkLoader {
   constructor(private scene: Phaser.Scene) {}
 
-  load(key: string) {
-    const data = this.scene.cache.json.get(key) as SimpleLDtk;
+  load(key: string, entityMap: Record<string, EntityConstructor> = {}) {
+    const data = this.scene.cache.json.get(key) as LDtkLevel;
     let collisionLayer: Phaser.Tilemaps.TilemapLayer | null = null;
+    const entities: Phaser.GameObjects.GameObject[] = [];
 
-    data.layers.forEach((layer) => {
-      const map = this.scene.make.tilemap({
-        data: layer.data,
-        tileWidth: data.tileSize,
-        tileHeight: data.tileSize
-      });
-      const tiles = map.addTilesetImage('tiles');
-      const tileLayer = map.createLayer(0, tiles, 0, 0);
-      if (layer.collides) {
+    data.layerInstances.forEach((layer) => {
+      if (layer.__type === 'IntGrid' && layer.intGridCsv) {
+        const width = layer.__cWid ?? 0;
+        const height = layer.__cHei ?? 0;
+        const grid: number[][] = [];
+        for (let y = 0; y < height; y++) {
+          const row: number[] = [];
+          for (let x = 0; x < width; x++) {
+            const val = layer.intGridCsv[y * width + x];
+            row.push(val > 0 ? 0 : -1);
+          }
+          grid.push(row);
+        }
+        const map = this.scene.make.tilemap({
+          data: grid,
+          tileWidth: layer.gridSize ?? 0,
+          tileHeight: layer.gridSize ?? 0
+        });
+        const tiles = map.addTilesetImage('tiles');
+        const tileLayer = map.createLayer(0, tiles, 0, 0);
         tileLayer.setCollisionByExclusion([-1]);
         collisionLayer = tileLayer;
+      } else if (layer.__type === 'Entities' && layer.entityInstances) {
+        layer.entityInstances.forEach((entity) => {
+          const Ctor = entityMap[entity.__identifier];
+          if (Ctor) {
+            const obj = new Ctor(this.scene, entity.px[0], entity.px[1]);
+            entities.push(obj);
+          }
+        });
       }
     });
 
-    return { collisionLayer };
+    return { collisionLayer, entities };
   }
 }


### PR DESCRIPTION
## Summary
- add placeholder LDtk project and level export
- parse LDtk levels and spawn mapped entities
- implement Player entity with basic movement and LDtk-driven spawning

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build` (fails: sh: 1: vite: Permission denied)


------
https://chatgpt.com/codex/tasks/task_e_6895f2b216548325af50955681dfaee3