### PR TITLE
feat: add virtual joystick controls

### DIFF
--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -22,7 +22,13 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
     } else {
       this.setVelocityX(0);
     }
-    if (this.input.jump && this.body.blocked.down) {
+    if (this.input.drop && this.body.blocked.down) {
+      this.body.checkCollision.down = false;
+      this.setVelocityY(100);
+      this.scene.time.delayedCall(250, () => {
+        this.body.checkCollision.down = true;
+      });
+    } else if (this.input.jump && this.body.blocked.down) {
       this.setVelocityY(-330);
     }
   }

--- a/src/systems/InputManager.ts
+++ b/src/systems/InputManager.ts
@@ -87,12 +87,16 @@ export default class InputManager {
     );
   }
 
-  get up() {
+  get lookUp() {
     return (
       this.cursors.up.isDown ||
       (this.wasd.W && this.wasd.W.isDown) ||
       this.joystickDir.y < -0.3
     );
+  }
+
+  get up() {
+    return this.lookUp;
   }
 
   get down() {
@@ -105,6 +109,10 @@ export default class InputManager {
 
   get jump() {
     return this.jumpKey.isDown || this.jumpPressed;
+  }
+
+  get drop() {
+    return this.down && this.jump;
   }
 
   get interact() {


### PR DESCRIPTION
## Summary
- add on-screen joystick and buttons using pointer events
- expose look up and drop inputs and handle drop-through

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build` (fails: vite: Permission denied)


------
https://chatgpt.com/codex/tasks/task_e_6895f75128588325acc6bb780050ec29