### PR TITLE
feat: load ink story dynamically

### DIFF
--- a/src/scenes/VisualNovel.ts
+++ b/src/scenes/VisualNovel.ts
@@ -1,39 +1,76 @@
 import Phaser from 'phaser';
-import { Story } from 'inkjs';
 import DialogueBox from '../ui/DialogueBox';
 
 export default class VisualNovel extends Phaser.Scene {
-  private story!: Story;
-  private dialogue!: DialogueBox;
+  private story?: any;
+  private dialogue?: DialogueBox;
+  private errorText?: Phaser.GameObjects.Text;
 
   constructor() {
     super('VisualNovel');
   }
 
   create() {
-    const data = this.cache.json.get('inkTest');
-    this.story = new Story(data);
-
-    this.dialogue = new DialogueBox(this);
-    this.dialogue.onNext(() => {
-      if (this.story.currentChoices.length === 0) {
-        this.advance();
-      }
-    });
-
     this.input.keyboard.on('keydown-V', () => this.scene.start('Play'));
+    this.input.keyboard.on('keydown-R', () => this.loadStory());
 
-    this.advance();
+    this.loadStory();
+  }
+
+  private async loadStory() {
+    this.story = undefined;
+    this.dialogue?.destroy();
+    this.dialogue = undefined;
+    this.errorText?.destroy();
+    this.errorText = undefined;
+
+    try {
+      const ink = await import('inkjs');
+      const res = await fetch('/assets/dialogue/sample.ink.json');
+      if (!res.ok) {
+        throw new Error('Failed to load file');
+      }
+
+      const data = await res.json();
+      if (data && typeof data === 'object' && 'inkVersion' in data) {
+        this.story = new ink.Story(data);
+
+        this.dialogue = new DialogueBox(this);
+        this.dialogue.onNext(() => {
+          if (this.story && this.story.currentChoices.length === 0) {
+            this.advance();
+          }
+        });
+
+        this.advance();
+        return;
+      }
+
+      throw new Error('Invalid Ink data');
+    } catch (err) {
+      this.errorText = this.add
+        .text(this.scale.width / 2, this.scale.height / 2, 'Dialogue not available', {
+          color: '#ffffff',
+          fontSize: '24px',
+          backgroundColor: '#000000',
+          padding: { x: 10, y: 10 }
+        })
+        .setOrigin(0.5);
+    }
   }
 
   private advance() {
+    if (!this.story || !this.dialogue) {
+      return;
+    }
+
     this.dialogue.clearChoices();
 
     if (this.story.canContinue) {
       const line = this.story.Continue().trim();
       this.dialogue.setText(line);
     } else if (this.story.currentChoices.length > 0) {
-      const choices = this.story.currentChoices.map((c) => c.text);
+      const choices = this.story.currentChoices.map((c: any) => c.text);
       this.dialogue.setChoices(choices, (index) => {
         this.story.ChooseChoiceIndex(index);
         this.advance();


### PR DESCRIPTION
## Summary
- dynamically import inkjs and fetch ink story at runtime
- handle missing modules or story files by showing a fallback message
- add R debug key to retry story loading

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: vite permission denied / missing module)*

------
https://chatgpt.com/codex/tasks/task_e_6895fad9d3ac8325af78226b889dd1f5