### PR TITLE
Handle missing LDtk level gracefully

### DIFF
--- a/src/scenes/Play.ts
+++ b/src/scenes/Play.ts
@@ -9,23 +9,60 @@ export default class Play extends Phaser.Scene {
     super('Play');
   }
 
-  create() {
-    const loader = new LDtkLoader(this);
-    const { collisionLayer, entities } = loader.load('level1', {
-      SpawnPoint: Player
-    });
-
-    this.player = entities.find((e) => e instanceof Player) as Player;
-
-    if (collisionLayer) {
-      this.physics.add.collider(this.player, collisionLayer);
-    }
-
-    this.cameras.main.startFollow(this.player);
+  async create() {
+    await this.loadLevel();
 
     // Hotkey to switch to Visual Novel scene
     this.input.keyboard.on('keydown-V', () => {
       this.scene.start('VisualNovel');
     });
+
+    // Debug key to retry loading the level
+    this.input.keyboard.on('keydown-L', () => {
+      this.scene.restart();
+    });
+  }
+
+  private async loadLevel() {
+    this.cache.json.remove('level1');
+    try {
+      const response = await fetch('/levels/lvl_01_test.json');
+      if (!response.ok) throw new Error('Missing level');
+      const data = await response.json();
+      this.cache.json.add('level1', data);
+      const loader = new LDtkLoader(this);
+      const { collisionLayer, entities } = loader.load('level1', {
+        SpawnPoint: Player
+      });
+
+      this.player = entities.find((e) => e instanceof Player) as Player;
+
+      if (collisionLayer) {
+        this.physics.add.collider(this.player, collisionLayer);
+      }
+
+      this.cameras.main.startFollow(this.player);
+    } catch (err) {
+      const width = this.scale.width;
+      const height = this.scale.height;
+      this.add
+        .text(width / 2, height / 2, 'Level not available')
+        .setOrigin(0.5);
+
+      const groundHeight = 50;
+      const ground = this.add
+        .rectangle(0, height - groundHeight, width, groundHeight, 0x00ff00)
+        .setOrigin(0, 0);
+      this.physics.add.existing(ground, true);
+
+      this.player = new Player(
+        this,
+        width / 2,
+        height - groundHeight - 50
+      );
+      this.physics.add.collider(this.player, ground);
+
+      this.cameras.main.startFollow(this.player);
+    }
   }
 }

--- a/src/scenes/Preload.ts
+++ b/src/scenes/Preload.ts
@@ -20,8 +20,7 @@ export default class Preload extends Phaser.Scene {
       'jump',
       'https://labs.phaser.io/assets/audio/SoundEffects/key.wav'
     );
-    // LDtk level and ink story
-    this.load.json('level1', '/levels/lvl_01_test.json');
+    // Ink story
     this.load.json('inkTest', '/dialogue/sample.ink.json');
   }
 


### PR DESCRIPTION
## Summary
- Stop preloading a specific LDtk level so the game can run without level data.
- Play scene now fetches the LDtk level at runtime and falls back to a simple test room with a player and ground when missing.
- Added debug key `L` to retry loading the LDtk level after adding the file.

## Testing
- `npm test` *(fails: no test specified)*
- `npm run dev` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_689602859a2483259c5dd5ac5b5a88c1