### PR TITLE
feat: add manifest-driven asset loader

### DIFF
--- a/src/config/manifest.json
+++ b/src/config/manifest.json
@@ -1,0 +1,7 @@
+{
+  "atlases": [],
+  "tilesets": ["assets/tilesets/overworld"],
+  "levels": ["assets/levels/lvl_01_test.json"],
+  "audio": { "bgm": [], "sfx": [] },
+  "fonts": []
+}

--- a/src/scenes/Preload.ts
+++ b/src/scenes/Preload.ts
@@ -1,4 +1,6 @@
 import Phaser from 'phaser';
+import manifest from '../config/manifest.json';
+import ManifestLoader from '../systems/ManifestLoader';
 
 export default class Preload extends Phaser.Scene {
   constructor() {
@@ -6,31 +8,8 @@ export default class Preload extends Phaser.Scene {
   }
 
   preload() {
-    // Create a single-tile checkerboard texture in memory
-    const canvas = document.createElement('canvas');
-    canvas.width = 32;
-    canvas.height = 32;
-    const ctx = canvas.getContext('2d');
-    if (ctx) {
-      ctx.fillStyle = '#ffffff';
-      ctx.fillRect(0, 0, 32, 32);
-      ctx.fillStyle = '#000000';
-      ctx.fillRect(0, 0, 16, 16);
-      ctx.fillRect(16, 16, 16, 16);
-    }
-    const dataURL = canvas.toDataURL('image/png');
-    this.textures.addBase64('tiles', dataURL);
-    this.load.spritesheet(
-      'player',
-      'https://labs.phaser.io/assets/sprites/dude.png',
-      { frameWidth: 32, frameHeight: 48 }
-    );
-    this.load.audio(
-      'jump',
-      'https://labs.phaser.io/assets/audio/SoundEffects/key.wav'
-    );
-    // Ink story
-    this.load.json('inkTest', '/dialogue/sample.ink.json');
+    const loader = new ManifestLoader(this.load);
+    loader.load(manifest);
   }
 
   create() {

--- a/src/systems/ManifestLoader.ts
+++ b/src/systems/ManifestLoader.ts
@@ -1,0 +1,76 @@
+import Phaser from 'phaser';
+
+interface Manifest {
+  atlases: string[];
+  tilesets: string[];
+  levels: string[];
+  audio: {
+    bgm: string[];
+    sfx: string[];
+  };
+  fonts: string[];
+}
+
+export default class ManifestLoader {
+  constructor(private loader: Phaser.Loader.LoaderPlugin) {}
+
+  load(manifest: Manifest) {
+    this.validate(manifest);
+
+    manifest.tilesets.forEach((path) => {
+      const key = this.keyFromPath(path);
+      this.loader.image(key, [path + '.webp', path + '.png']);
+    });
+
+    manifest.atlases.forEach((path) => {
+      const key = this.keyFromPath(path);
+      this.loader.atlas(key, path + '.json', [path + '.webp', path + '.png']);
+    });
+
+    manifest.levels.forEach((path) => {
+      const key = this.keyFromPath(path);
+      this.loader.json(key, path);
+    });
+
+    manifest.audio.bgm.forEach((path) => {
+      const key = this.keyFromPath(path);
+      this.loader.audio(key, [path + '.ogg', path + '.mp3']);
+    });
+
+    manifest.audio.sfx.forEach((path) => {
+      const key = this.keyFromPath(path);
+      this.loader.audio(key, [path + '.ogg', path + '.mp3']);
+    });
+
+    // Fonts are included for completeness; implementation depends on font type.
+  }
+
+  private validate(manifest: Manifest) {
+    const required: (keyof Manifest)[] = [
+      'atlases',
+      'tilesets',
+      'levels',
+      'audio',
+      'fonts'
+    ];
+    for (const key of required) {
+      if (!(key in manifest)) {
+        throw new Error(`Manifest missing key: ${key}`);
+      }
+    }
+    if (!manifest.levels || manifest.levels.length === 0) {
+      throw new Error('Manifest missing key: levels');
+    }
+    if (!manifest.audio.bgm) {
+      throw new Error('Manifest missing key: audio.bgm');
+    }
+    if (!manifest.audio.sfx) {
+      throw new Error('Manifest missing key: audio.sfx');
+    }
+  }
+
+  private keyFromPath(path: string) {
+    const parts = path.split('/');
+    return parts[parts.length - 1];
+  }
+}


### PR DESCRIPTION
## Summary
- define a starter asset manifest
- load assets through a ManifestLoader with image/audio fallbacks
- boot Preload scene using manifest

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689613b667e883259f68faaf0a56a6a8