### PR TITLE
Add physics adapter and event-driven player controller

### DIFF
--- a/src/entities/DialogueTrigger.ts
+++ b/src/entities/DialogueTrigger.ts
@@ -1,18 +1,25 @@
 import Phaser from 'phaser';
+import PhysicsAdapter from '../physics/PhysicsAdapter';
 
 export default class DialogueTrigger extends Phaser.GameObjects.Zone {
-  constructor(scene: Phaser.Scene, x: number, y: number) {
+  private physics: PhysicsAdapter;
+
+  constructor(scene: Phaser.Scene, physics: PhysicsAdapter, x: number, y: number) {
     super(scene, x, y, 32, 32);
+    this.physics = physics;
     scene.add.existing(this);
-    scene.physics.add.existing(this);
     this.setOrigin(0, 0);
-    const body = this.body as Phaser.Physics.Arcade.Body;
-    body.setAllowGravity(false);
-    body.setImmovable(true);
+    this.physics.createBody('static', {
+      gameObject: this,
+      width: 32,
+      height: 32,
+      immovable: true,
+      allowGravity: false
+    });
   }
 
   setup(player: Phaser.GameObjects.GameObject) {
-    this.scene.physics.add.overlap(player, this, () => {
+    this.physics.overlap(player, this, () => {
       this.scene.scene.start('VisualNovel');
     });
   }

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -1,35 +1,95 @@
 import Phaser from 'phaser';
 import InputManager from '../systems/InputManager';
+import PhysicsAdapter, { PhysicsBody } from '../physics/PhysicsAdapter';
 
-export default class Player extends Phaser.Physics.Arcade.Sprite {
+export default class Player extends Phaser.GameObjects.Sprite {
   public input: InputManager;
+  private physics: PhysicsAdapter;
+  private bodyRef: PhysicsBody;
+  private moveDir = new Phaser.Math.Vector2();
+  private lookDir = new Phaser.Math.Vector2();
+  private coyoteTime = 100;
+  private coyoteTimer = 0;
+  private jumpBuffer = 90;
+  private jumpTimer = 0;
+  private speed = 160;
+  private jumpSpeed = 330;
 
-  constructor(scene: Phaser.Scene, x: number, y: number) {
+  constructor(scene: Phaser.Scene, physics: PhysicsAdapter, x: number, y: number) {
     super(scene, x, y, 'player');
     scene.add.existing(this);
-    scene.physics.add.existing(this);
-    this.setBounce(0.1);
+    this.setOrigin(0.5, 28 / 32);
+    this.physics = physics;
+    this.bodyRef = this.physics.createBody('dynamic', {
+      gameObject: this,
+      width: 20,
+      height: 28,
+      offsetX: 6,
+      offsetY: 4
+    });
     this.input = new InputManager(scene);
+    this.input.on('move', (v: Phaser.Math.Vector2) => {
+      this.moveDir.copy(v);
+    });
+    this.input.on('look', (v: Phaser.Math.Vector2) => {
+      this.lookDir.copy(v);
+      this.updateCameraLook();
+    });
+    this.input.on('jump', () => {
+      this.jumpTimer = this.jumpBuffer;
+    });
+    this.input.on('drop', () => {
+      this.tryDropThrough();
+    });
+  }
+
+  private tryDropThrough() {
+    const body = this.bodyRef.raw as Phaser.Physics.Arcade.Body;
+    if (body.blocked.down) {
+      body.checkCollision.down = false;
+      this.physics.setVelocity(this.bodyRef, body.velocity.x, 100);
+      this.scene.time.delayedCall(250, () => {
+        body.checkCollision.down = true;
+      });
+    }
+  }
+
+  private updateCameraLook() {
+    const cam = this.scene.cameras.main;
+    const body = this.bodyRef.raw as Phaser.Physics.Arcade.Body;
+    if (body.blocked.down && Math.abs(this.moveDir.x) < 0.01) {
+      if (this.lookDir.y < -0.5) {
+        cam.setFollowOffset(0, -50);
+      } else if (this.lookDir.y > 0.5) {
+        cam.setFollowOffset(0, 50);
+      } else {
+        cam.setFollowOffset(0, 0);
+      }
+    } else {
+      cam.setFollowOffset(0, 0);
+    }
   }
 
   preUpdate(time: number, delta: number) {
     super.preUpdate(time, delta);
-    const speed = 160;
-    if (this.input.left) {
-      this.setVelocityX(-speed);
-    } else if (this.input.right) {
-      this.setVelocityX(speed);
-    } else {
-      this.setVelocityX(0);
+    const body = this.bodyRef.raw as Phaser.Physics.Arcade.Body;
+
+    this.physics.setVelocity(this.bodyRef, this.moveDir.x * this.speed, body.velocity.y);
+
+    if (body.blocked.down) {
+      this.coyoteTimer = this.coyoteTime;
+    } else if (this.coyoteTimer > 0) {
+      this.coyoteTimer -= delta;
     }
-    if (this.input.dropThrough && this.body.blocked.down) {
-      this.body.checkCollision.down = false;
-      this.setVelocityY(100);
-      this.scene.time.delayedCall(250, () => {
-        this.body.checkCollision.down = true;
-      });
-    } else if (this.input.jumpPressed && this.body.blocked.down) {
-      this.setVelocityY(-330);
+
+    if (this.jumpTimer > 0) {
+      this.jumpTimer -= delta;
+    }
+
+    if (this.jumpTimer > 0 && (body.blocked.down || this.coyoteTimer > 0)) {
+      this.physics.setVelocity(this.bodyRef, body.velocity.x, -this.jumpSpeed);
+      this.jumpTimer = 0;
+      this.coyoteTimer = 0;
     }
   }
 }

--- a/src/physics/ArcadeAdapter.ts
+++ b/src/physics/ArcadeAdapter.ts
@@ -1,0 +1,46 @@
+import Phaser from 'phaser';
+import PhysicsAdapter, { PhysicsBody, BodyOptions } from './PhysicsAdapter';
+
+export default class ArcadeAdapter implements PhysicsAdapter {
+  constructor(private scene: Phaser.Scene) {}
+
+  setGravity(x: number, y: number): void {
+    this.scene.physics.world.gravity.set(x, y);
+  }
+
+  createBody(type: 'dynamic' | 'static', opts: BodyOptions): PhysicsBody {
+    this.scene.physics.add.existing(opts.gameObject, type === 'static');
+    const body = (opts.gameObject.body as Phaser.Physics.Arcade.Body);
+    if (opts.width && opts.height) body.setSize(opts.width, opts.height);
+    if (opts.offsetX || opts.offsetY) body.setOffset(opts.offsetX ?? 0, opts.offsetY ?? 0);
+    if (opts.immovable !== undefined) body.setImmovable(opts.immovable);
+    if (opts.allowGravity === false) body.setAllowGravity(false);
+    return { raw: body };
+  }
+
+  setVelocity(body: PhysicsBody, vx: number, vy: number): void {
+    (body.raw as Phaser.Physics.Arcade.Body).setVelocity(vx, vy);
+  }
+
+  applyImpulse(body: PhysicsBody, vx: number, vy: number): void {
+    const b = body.raw as Phaser.Physics.Arcade.Body;
+    b.setVelocity(b.velocity.x + vx, b.velocity.y + vy);
+  }
+
+  collide(obj1: any, obj2: any, cb?: Phaser.Types.Physics.Arcade.ArcadeColliderCallback) {
+    return this.scene.physics.add.collider(obj1, obj2, cb);
+  }
+
+  overlap(obj1: any, obj2: any, cb?: Phaser.Types.Physics.Arcade.ArcadeColliderCallback) {
+    return this.scene.physics.add.overlap(obj1, obj2, cb);
+  }
+
+  raycast(from: Phaser.Math.Vector2, to: Phaser.Math.Vector2) {
+    // Stub: Arcade Physics doesn't have built-in raycast
+    return null;
+  }
+
+  destroy(): void {
+    // no-op for Arcade
+  }
+}

--- a/src/physics/PhysicsAdapter.ts
+++ b/src/physics/PhysicsAdapter.ts
@@ -1,0 +1,27 @@
+import Phaser from "phaser";
+
+export interface PhysicsBody {
+  /** Underlying physics-specific body */
+  raw: any;
+}
+
+export interface BodyOptions {
+  gameObject: Phaser.GameObjects.GameObject;
+  width?: number;
+  height?: number;
+  offsetX?: number;
+  offsetY?: number;
+  immovable?: boolean;
+  allowGravity?: boolean;
+}
+
+export default interface PhysicsAdapter {
+  setGravity(x: number, y: number): void;
+  createBody(type: 'dynamic' | 'static', opts: BodyOptions): PhysicsBody;
+  setVelocity(body: PhysicsBody, vx: number, vy: number): void;
+  applyImpulse(body: PhysicsBody, vx: number, vy: number): void;
+  collide(obj1: any, obj2: any, cb?: Phaser.Types.Physics.Arcade.ArcadeColliderCallback): Phaser.Physics.Arcade.Collider | void;
+  overlap(obj1: any, obj2: any, cb?: Phaser.Types.Physics.Arcade.ArcadeColliderCallback): Phaser.Physics.Arcade.Collider | void;
+  raycast(from: Phaser.Math.Vector2, to: Phaser.Math.Vector2): any;
+  destroy(): void;
+}

--- a/src/systems/InputManager.ts
+++ b/src/systems/InputManager.ts
@@ -1,6 +1,6 @@
 import Phaser from 'phaser';
 
-export default class InputManager {
+export default class InputManager extends Phaser.Events.EventEmitter {
   private scene: Phaser.Scene;
   private cursors: Phaser.Types.Input.Keyboard.CursorKeys;
   private wasd: { [key: string]: Phaser.Input.Keyboard.Key };
@@ -20,7 +20,12 @@ export default class InputManager {
   private dropThroughFlag = false;
   private dropComboPrev = false;
 
+  private prevMove = new Phaser.Math.Vector2();
+  private prevLook = new Phaser.Math.Vector2();
+  private prevJump = false;
+
   constructor(scene: Phaser.Scene) {
+    super();
     this.scene = scene;
 
     this.cursors = scene.input.keyboard.createCursorKeys();
@@ -153,6 +158,27 @@ export default class InputManager {
     const combo = this.down && this.jumpPressed;
     this.dropThroughFlag = combo && !this.dropComboPrev;
     this.dropComboPrev = combo;
+
+    const move = this.move;
+    if (!move.equals(this.prevMove)) {
+      this.prevMove.copy(move);
+      this.emit('move', move.clone());
+    }
+
+    const look = this.look;
+    if (!look.equals(this.prevLook)) {
+      this.prevLook.copy(look);
+      this.emit('look', look.clone());
+    }
+
+    if (this.jumpPressed && !this.prevJump) {
+      this.emit('jump');
+    }
+    this.prevJump = this.jumpPressed;
+
+    if (this.dropThroughFlag) {
+      this.emit('drop');
+    }
   }
 
   private logInputs() {

--- a/src/systems/LDtkLoader.ts
+++ b/src/systems/LDtkLoader.ts
@@ -1,6 +1,12 @@
 import Phaser from 'phaser';
+import PhysicsAdapter from '../physics/PhysicsAdapter';
 
-type EntityConstructor = new (scene: Phaser.Scene, x: number, y: number) => Phaser.GameObjects.GameObject;
+type EntityConstructor = new (
+  scene: Phaser.Scene,
+  physics: PhysicsAdapter,
+  x: number,
+  y: number
+) => Phaser.GameObjects.GameObject;
 
 interface LDtkEntity {
   __identifier: string;
@@ -24,7 +30,7 @@ interface LDtkLevel {
 }
 
 export default class LDtkLoader {
-  constructor(private scene: Phaser.Scene) {}
+  constructor(private scene: Phaser.Scene, private physics: PhysicsAdapter) {}
 
   load(key: string, entityMap: Record<string, EntityConstructor> = {}) {
     const data = this.scene.cache.json.get(key) as LDtkLevel;
@@ -57,7 +63,7 @@ export default class LDtkLoader {
         layer.entityInstances.forEach((entity) => {
           const Ctor = entityMap[entity.__identifier];
           if (Ctor) {
-            const obj = new Ctor(this.scene, entity.px[0], entity.px[1]);
+            const obj = new Ctor(this.scene, this.physics, entity.px[0], entity.px[1]);
             entities.push(obj);
           }
         });


### PR DESCRIPTION
## Summary
- Abstract physics calls through a `PhysicsAdapter` with an Arcade implementation.
- Refactor `InputManager` to emit move/look/jump/drop events.
- Replace player with tight controller supporting coyote time, jump buffer, drop-through platforms and camera look panning.
- Update scenes and entities to use the adapter instead of direct Arcade calls.

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_689619940a7483258253f237b3c02f1b