### PR TITLE
Add LDtk level and procedural tileset

### DIFF
--- a/assets/config.json
+++ b/assets/config.json
@@ -1,3 +1,3 @@
 {
-  "startLevel": "level1"
+  "startLevel": "lvl_01_test"
 }

--- a/assets/levels/lvl_01_test.json
+++ b/assets/levels/lvl_01_test.json
@@ -1,7 +1,16 @@
 {
+  "__identifier": "lvl_01_test",
   "pxWid": 1280,
   "pxHei": 384,
   "layerInstances": [
+    {
+      "__identifier": "Background",
+      "__type": "Tiles",
+      "gridSize": 32,
+      "__cWid": 40,
+      "__cHei": 12,
+      "gridTiles": []
+    },
     {
       "__identifier": "Ground",
       "__type": "IntGrid",
@@ -492,18 +501,33 @@
       ]
     },
     {
+      "__identifier": "Foreground",
+      "__type": "Tiles",
+      "gridSize": 32,
+      "__cWid": 40,
+      "__cHei": 12,
+      "gridTiles": []
+    },
+    {
       "__identifier": "Entities",
       "__type": "Entities",
+      "gridSize": 32,
       "entityInstances": [
         {
-          "__identifier": "SpawnPoint",
+          "__identifier": "spawn",
           "px": [
             64,
             256
+          ],
+          "fieldInstances": [
+            {
+              "__identifier": "facing",
+              "__value": "right"
+            }
           ]
         },
         {
-          "__identifier": "Dialogue",
+          "__identifier": "dialogue",
           "px": [
             320,
             256
@@ -512,10 +536,26 @@
             {
               "__identifier": "knot",
               "__value": "intro"
+            },
+            {
+              "__identifier": "once",
+              "__value": true
+            },
+            {
+              "__identifier": "facingLock",
+              "__value": false
             }
           ]
         }
       ]
+    },
+    {
+      "__identifier": "Decor",
+      "__type": "Tiles",
+      "gridSize": 32,
+      "__cWid": 40,
+      "__cHei": 12,
+      "gridTiles": []
     }
   ]
 }

--- a/assets/levels/world.ldtk
+++ b/assets/levels/world.ldtk
@@ -1,0 +1,18 @@
+{
+  "identifier": "world",
+  "levels": [
+    {
+      "identifier": "lvl_01_test",
+      "uid": 1,
+      "worldX": 0,
+      "worldY": 0,
+      "pxWid": 1280,
+      "pxHei": 384,
+      "externalRelPath": "lvl_01_test.json"
+    }
+  ],
+  "defs": {
+    "layers": [],
+    "entities": []
+  }
+}

--- a/src/config/manifest.json
+++ b/src/config/manifest.json
@@ -1,7 +1,7 @@
 {
   "atlases": [],
-  "tilesets": ["assets/tilesets/overworld"],
-  "levels": ["assets/levels/lvl_01_test.json"],
+  "tilesets": [],
+  "levels": ["assets/levels/world.ldtk", "assets/levels/lvl_01_test.json"],
   "audio": { "bgm": [], "sfx": [] },
   "fonts": []
 }

--- a/src/scenes/MainMenu.ts
+++ b/src/scenes/MainMenu.ts
@@ -18,7 +18,7 @@ export default class MainMenu extends Phaser.Scene {
 
     this.input.keyboard.on('keydown-N', () => {
       const fresh: GameSnapshot = {
-        levelId: 'level1',
+        levelId: 'lvl_01_test',
         checkpointId: 'start',
         player: { x: 0, y: 0, hp: 100, inventory: [] },
         inkStateJson: null,

--- a/src/scenes/Play.ts
+++ b/src/scenes/Play.ts
@@ -46,16 +46,11 @@ export default class Play extends Phaser.Scene {
   }
 
   private async loadLevel() {
-    this.cache.json.remove('level1');
     try {
-      const response = await fetch('/levels/lvl_01_test.json');
-      if (!response.ok) throw new Error('Missing level');
-      const data = await response.json();
-      this.cache.json.add('level1', data);
       const loader = new LDtkLoader(this, this.physicsAdapter);
-      const { collisionLayer, entities } = loader.load('level1', {
-        SpawnPoint: Player,
-        Dialogue: DialogueTrigger
+      const { collisionLayer, entities } = loader.load('lvl_01_test.json', {
+        spawn: Player,
+        dialogue: DialogueTrigger
       });
 
       this.player = entities.find((e) => e instanceof Player) as Player;
@@ -63,7 +58,7 @@ export default class Play extends Phaser.Scene {
         this.checkpointId = this.startSnapshot.checkpointId;
         this.player.restore(this.startSnapshot.player);
       }
-      SaveManager.updateLevel('level1', this.checkpointId);
+      SaveManager.updateLevel('lvl_01_test', this.checkpointId);
       SaveManager.updatePlayer(this.player.getSnapshot());
       SaveManager.saveAuto();
 
@@ -104,7 +99,7 @@ export default class Play extends Phaser.Scene {
         this.checkpointId = this.startSnapshot.checkpointId;
         this.player.restore(this.startSnapshot.player);
       }
-      SaveManager.updateLevel('level1', this.checkpointId);
+      SaveManager.updateLevel('lvl_01_test', this.checkpointId);
       SaveManager.updatePlayer(this.player.getSnapshot());
       SaveManager.saveAuto();
 
@@ -137,7 +132,7 @@ export default class Play extends Phaser.Scene {
   // Simulated checkpoint trigger for autosave
   public hitCheckpoint(id: string) {
     this.checkpointId = id;
-    SaveManager.updateLevel('level1', this.checkpointId);
+    SaveManager.updateLevel('lvl_01_test', this.checkpointId);
     SaveManager.updatePlayer(this.player.getSnapshot());
     SaveManager.saveAuto();
   }

--- a/src/scenes/Preload.ts
+++ b/src/scenes/Preload.ts
@@ -14,6 +14,14 @@ export default class Preload extends Phaser.Scene {
   }
 
   create() {
+    const graphics = this.add.graphics();
+    graphics.fillStyle(0xcccccc, 1);
+    graphics.fillRect(0, 0, 16, 16);
+    graphics.fillStyle(0x888888, 1);
+    graphics.fillRect(16, 16, 16, 16);
+    graphics.generateTexture('tile32', 32, 32);
+    graphics.destroy();
+
     const snap = SaveManager.loadAuto();
     if (snap) {
       this.scene.start('Play', { snapshot: snap });

--- a/src/systems/LDtkLoader.ts
+++ b/src/systems/LDtkLoader.ts
@@ -55,10 +55,42 @@ export default class LDtkLoader {
           tileWidth: layer.gridSize ?? 0,
           tileHeight: layer.gridSize ?? 0
         });
-        const tiles = map.addTilesetImage('tiles');
+        const tiles = map.addTilesetImage('tile32');
         const tileLayer = map.createLayer(0, tiles, 0, 0);
-        tileLayer.setCollisionByExclusion([-1]);
-        collisionLayer = tileLayer;
+        if (layer.__identifier === 'Ground') {
+          tileLayer.setCollisionByExclusion([-1]);
+          collisionLayer = tileLayer;
+        }
+      } else if (
+        (layer.__type === 'Tiles' || layer.__type === 'AutoLayer') &&
+        (layer as any).gridTiles
+      ) {
+        const width = layer.__cWid ?? 0;
+        const height = layer.__cHei ?? 0;
+        const grid: number[][] = Array.from({ length: height }, () =>
+          Array(width).fill(-1)
+        );
+        const tilesData = (layer as any).gridTiles as {
+          px: [number, number];
+        }[];
+        tilesData.forEach((t) => {
+          const gx = Math.floor(t.px[0] / (layer.gridSize ?? 1));
+          const gy = Math.floor(t.px[1] / (layer.gridSize ?? 1));
+          if (gy >= 0 && gy < height && gx >= 0 && gx < width) {
+            grid[gy][gx] = 0;
+          }
+        });
+        const map = this.scene.make.tilemap({
+          data: grid,
+          tileWidth: layer.gridSize ?? 0,
+          tileHeight: layer.gridSize ?? 0
+        });
+        const tiles = map.addTilesetImage('tile32');
+        const tileLayer = map.createLayer(0, tiles, 0, 0);
+        if (layer.__identifier === 'Ground') {
+          tileLayer.setCollisionByExclusion([-1]);
+          collisionLayer = tileLayer;
+        }
       } else if (layer.__type === 'Entities' && layer.entityInstances) {
         layer.entityInstances.forEach((entity) => {
           const Ctor = entityMap[entity.__identifier];

--- a/src/systems/SaveManager.ts
+++ b/src/systems/SaveManager.ts
@@ -18,7 +18,7 @@ export default class SaveManager {
   private static readonly SLOT_PREFIX = 'save_slot_';
 
   private static current: GameSnapshot = {
-    levelId: 'level1',
+    levelId: 'lvl_01_test',
     checkpointId: 'start',
     player: { x: 0, y: 0, hp: 100, inventory: [] },
     inkStateJson: null,


### PR DESCRIPTION
## Summary
- Generate 32px checker tile at runtime and use it for LDtk maps
- Load new LDtk world and level with spawn and dialogue entities
- Default saves and menu to new level

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68969690286483259211bee2fdea77c1