### PR TITLE
Persist dialogue triggers and return to Play after VN

### DIFF
--- a/src/entities/DialogueTrigger.ts
+++ b/src/entities/DialogueTrigger.ts
@@ -1,12 +1,25 @@
 import Phaser from 'phaser';
 import PhysicsAdapter from '../physics/PhysicsAdapter';
+import SaveManager from '../systems/SaveManager';
 
 export default class DialogueTrigger extends Phaser.GameObjects.Zone {
   private physics: PhysicsAdapter;
+  private knot?: string;
+  private once = false;
+  private id: string;
 
-  constructor(scene: Phaser.Scene, physics: PhysicsAdapter, x: number, y: number) {
+  constructor(
+    scene: Phaser.Scene,
+    physics: PhysicsAdapter,
+    x: number,
+    y: number,
+    data?: Record<string, any>
+  ) {
     super(scene, x, y, 32, 32);
     this.physics = physics;
+    this.knot = data?.knot;
+    this.once = !!data?.once;
+    this.id = data?.id || this.knot || `${x}_${y}`;
     scene.add.existing(this);
     this.setOrigin(0, 0);
     this.physics.createBody('static', {
@@ -19,8 +32,17 @@ export default class DialogueTrigger extends Phaser.GameObjects.Zone {
   }
 
   setup(player: Phaser.GameObjects.GameObject) {
+    if (this.once && SaveManager.getFlag(`dialogue_${this.id}`)) {
+      this.destroy();
+      return;
+    }
+
     this.physics.overlap(player, this, () => {
-      this.scene.scene.start('VisualNovel');
+      if (this.once) {
+        SaveManager.setFlag(`dialogue_${this.id}`, true);
+        SaveManager.saveAuto();
+      }
+      this.scene.scene.start('VisualNovel', { knot: this.knot });
     });
   }
 }

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -17,7 +17,13 @@ export default class Player extends Phaser.GameObjects.Sprite {
   private hp = 100;
   private inventory: string[] = [];
 
-  constructor(scene: Phaser.Scene, physics: PhysicsAdapter, x: number, y: number) {
+  constructor(
+    scene: Phaser.Scene,
+    physics: PhysicsAdapter,
+    x: number,
+    y: number,
+    _data?: Record<string, any>
+  ) {
     super(scene, x, y, 'player');
     scene.add.existing(this);
     this.setOrigin(0.5, 28 / 32);

--- a/src/systems/LDtkLoader.ts
+++ b/src/systems/LDtkLoader.ts
@@ -5,12 +5,19 @@ type EntityConstructor = new (
   scene: Phaser.Scene,
   physics: PhysicsAdapter,
   x: number,
-  y: number
+  y: number,
+  data?: Record<string, any>
 ) => Phaser.GameObjects.GameObject;
+
+interface LDtkField {
+  __identifier: string;
+  __value: any;
+}
 
 interface LDtkEntity {
   __identifier: string;
   px: [number, number];
+  fieldInstances?: LDtkField[];
 }
 
 interface LDtkLayer {
@@ -95,7 +102,17 @@ export default class LDtkLoader {
         layer.entityInstances.forEach((entity) => {
           const Ctor = entityMap[entity.__identifier];
           if (Ctor) {
-            const obj = new Ctor(this.scene, this.physics, entity.px[0], entity.px[1]);
+            const fields: Record<string, any> = {};
+            entity.fieldInstances?.forEach((f) => {
+              fields[f.__identifier] = f.__value;
+            });
+            const obj = new Ctor(
+              this.scene,
+              this.physics,
+              entity.px[0],
+              entity.px[1],
+              fields
+            );
             entities.push(obj);
           }
         });

--- a/src/systems/SaveManager.ts
+++ b/src/systems/SaveManager.ts
@@ -50,6 +50,14 @@ export default class SaveManager {
     this.current.flags = flags;
   }
 
+  static getFlag(key: string) {
+    return this.current.flags[key];
+  }
+
+  static setFlag(key: string, value: any = true) {
+    this.current.flags[key] = value;
+  }
+
   static saveAuto() {
     try {
       localStorage.setItem(this.AUTO_KEY, JSON.stringify(this.current));


### PR DESCRIPTION
## Summary
- Pass LDtk entity fields into constructors and track dialog triggers with SaveManager flags
- Launch VisualNovel from DialogueTrigger once and return to Play on completion
- Clear ink state and accept dialogue knot when loading VisualNovel

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build` (fails: Cannot find module @rollup/rollup-linux-x64-gnu)


------
https://chatgpt.com/codex/tasks/task_e_6896997ac8788325a465e7567772827e