### PR TITLE
Automatically queue LDtk project levels

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,2 +1,9 @@
 # Koram.G_2D_plat_vn
 
+## Adding new levels
+
+Levels are authored using [LDtk](https://ldtk.io/). When adding new levels to the game,
+include only the LDtk project file in `src/config/manifest.json`. The
+`ManifestLoader` will automatically parse the project and queue all referenced
+external level files, so there is no need to list each level JSON individually.
+

--- a/src/config/manifest.json
+++ b/src/config/manifest.json
@@ -1,7 +1,7 @@
 {
   "atlases": [],
   "tilesets": [],
-  "levels": ["assets/levels/world.ldtk", "assets/levels/lvl_01_test.json"],
+  "levels": ["assets/levels/world.ldtk"],
   "audio": { "bgm": [], "sfx": [] },
   "fonts": []
 }

--- a/src/systems/ManifestLoader.ts
+++ b/src/systems/ManifestLoader.ts
@@ -11,7 +11,12 @@ interface Manifest {
   fonts: string[];
 }
 
+interface LDtkProject {
+  levels?: { externalRelPath: string }[];
+}
+
 export default class ManifestLoader {
+  private queued = new Set<string>();
   constructor(private loader: Phaser.Loader.LoaderPlugin) {}
 
   load(manifest: Manifest) {
@@ -28,8 +33,25 @@ export default class ManifestLoader {
     });
 
     manifest.levels.forEach((path) => {
+      if (this.queued.has(path)) {
+        return;
+      }
       const key = this.keyFromPath(path);
       this.loader.json(key, path);
+      this.queued.add(path);
+      if (path.endsWith('.ldtk')) {
+        const base = path.substring(0, path.lastIndexOf('/') + 1);
+        this.loader.once(`filecomplete-json-${key}`, (_key: string, _type: string, data: LDtkProject) => {
+          data.levels?.forEach((level) => {
+            const levelPath = base + level.externalRelPath;
+            if (!this.queued.has(levelPath)) {
+              const levelKey = this.keyFromPath(levelPath);
+              this.loader.json(levelKey, levelPath);
+              this.queued.add(levelPath);
+            }
+          });
+        });
+      }
     });
 
     manifest.audio.bgm.forEach((path) => {


### PR DESCRIPTION
## Summary
- Detect `.ldtk` entries in the asset manifest and load any external level JSON files they reference
- Remove explicit level JSONs from the manifest and document the LDtk project workflow

## Testing
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68981604dbf483259b12cc40eaf66f98