### PR TITLE
chore: remove unused boot config load

### DIFF
--- a/src/scenes/Boot.ts
+++ b/src/scenes/Boot.ts
@@ -6,8 +6,7 @@ export default class Boot extends Phaser.Scene {
   }
 
   preload() {
-    // Load configuration or any immediate assets
-    this.load.json('config', '/config.json');
+    // No configuration needed at boot time
   }
 
   create() {


### PR DESCRIPTION
## Summary
- avoid 404s by removing unused config load in Boot scene

## Testing
- `npm test` (fails: Error: no test specified)
- `node node_modules/vite/bin/vite.js build` (fails: Cannot find module '@rollup/rollup-linux-x64-gnu')

------
https://chatgpt.com/codex/tasks/task_e_6898206d5bc88325911e1800ed90d2f0