### PR TITLE
Use full path keys for LDtk levels

### DIFF
--- a/src/scenes/Play.ts
+++ b/src/scenes/Play.ts
@@ -48,7 +48,7 @@ export default class Play extends Phaser.Scene {
   private async loadLevel() {
     try {
       const loader = new LDtkLoader(this, this.physicsAdapter);
-      const { collisionLayer, entities } = loader.load('world.ldtk', {
+      const { collisionLayer, entities } = loader.load('assets/levels/world.ldtk', {
         levelId: 'lvl_01',
         factories: {
           spawn: Player,

--- a/src/systems/LDtkLoader.ts
+++ b/src/systems/LDtkLoader.ts
@@ -55,8 +55,12 @@ interface LoadOptions {
 export default class LDtkLoader {
   constructor(private scene: Phaser.Scene, private physics: PhysicsAdapter) {}
 
+  private keyFromPath(path: string) {
+    return path.replace(/\//g, '_');
+  }
+
   load(
-    key: string,
+    path: string,
     options: LoadOptions | Record<string, EntityConstructor> = {}
   ) {
     // Backward compatibility: allow passing factories map directly
@@ -66,27 +70,29 @@ export default class LDtkLoader {
 
     const factories = opts.factories ?? {};
 
-    if (key.endsWith('.ldtk')) {
+    const cacheKey = this.keyFromPath(path);
+
+    if (path.endsWith('.ldtk')) {
       if (!opts.levelId) {
         throw new Error(
           'LDtkLoader: levelId is required when loading a .ldtk project'
         );
       }
-      const project = this.scene.cache.json.get(key) as LDtkProject;
+      const project = this.scene.cache.json.get(cacheKey) as LDtkProject;
       const levelRef = project?.levels?.find(
         (l) => l.identifier === opts.levelId
       );
       if (!levelRef) {
         throw new Error(
-          `LDtkLoader: level '${opts.levelId}' not found in ${key}`
+          `LDtkLoader: level '${opts.levelId}' not found in ${path}`
         );
       }
-      const levelKey = levelRef.externalRelPath;
+      const levelKey = this.keyFromPath(levelRef.externalRelPath);
       const levelData = this.scene.cache.json.get(levelKey) as LDtkLevel;
       return this.buildLevel(levelData, factories);
     }
 
-    const levelData = this.scene.cache.json.get(key) as LDtkLevel;
+    const levelData = this.scene.cache.json.get(cacheKey) as LDtkLevel;
     return this.buildLevel(levelData, factories);
   }
 

--- a/src/systems/ManifestLoader.ts
+++ b/src/systems/ManifestLoader.ts
@@ -92,7 +92,6 @@ export default class ManifestLoader {
   }
 
   private keyFromPath(path: string) {
-    const parts = path.split('/');
-    return parts[parts.length - 1];
+    return path.replace(/\//g, '_');
   }
 }


### PR DESCRIPTION
## Summary
- Derive asset keys from full relative paths to avoid name collisions
- Update LDtkLoader to retrieve level data using the new path-based keys
- Load levels in Play scene using full paths

## Testing
- `npm test` *(fails: no test specified)*
- `node -e "const fs=require('fs');function keyFromPath(p){return p.replace(/\\/g,'/').replace(/\//g,'_');}const paths=['assets/test_levels/a/lvl_01.json','assets/test_levels/b/lvl_01.json'];const cache={};for(const p of paths){cache[keyFromPath(p)]=JSON.parse(fs.readFileSync(p,'utf8'));}console.log('keys',Object.keys(cache));console.log('A width',cache[keyFromPath(paths[0])].pxWid);console.log('B width',cache[keyFromPath(paths[1])].pxWid);"`


------
https://chatgpt.com/codex/tasks/task_e_68982eacf12c832584cf2534330828d9