### PR TITLE
feat: add double jump pickup

### DIFF
--- a/assets/levels/lvl_01.json
+++ b/assets/levels/lvl_01.json
@@ -56,6 +56,26 @@
             }
           ],
           "defUid": 2
+        },
+        {
+          "__identifier": "pickup",
+          "px": [
+            640,
+            256
+          ],
+          "fieldInstances": [
+            {
+              "__identifier": "slot",
+              "__value": "A",
+              "defUid": 7
+            },
+            {
+              "__identifier": "id",
+              "__value": "double_jump",
+              "defUid": 8
+            }
+          ],
+          "defUid": 4
         }
       ],
       "layerDefUid": 2

--- a/src/entities/Pickup.ts
+++ b/src/entities/Pickup.ts
@@ -1,0 +1,42 @@
+import Phaser from 'phaser';
+import PhysicsAdapter from '../physics/PhysicsAdapter';
+import SaveManager from '../systems/SaveManager';
+
+export default class Pickup extends Phaser.GameObjects.Zone {
+  private physics: PhysicsAdapter;
+  private flag: string;
+
+  constructor(
+    scene: Phaser.Scene,
+    physics: PhysicsAdapter,
+    x: number,
+    y: number,
+    data?: Record<string, any>
+  ) {
+    super(scene, x, y, 32, 32);
+    this.physics = physics;
+    this.flag = data?.grantsVar || data?.id || 'pickup';
+    scene.add.existing(this);
+    this.setOrigin(0, 0);
+    this.physics.createBody('static', {
+      gameObject: this,
+      width: 32,
+      height: 32,
+      immovable: true,
+      allowGravity: false
+    });
+  }
+
+  setup(player: Phaser.GameObjects.GameObject) {
+    if (SaveManager.getFlag(this.flag)) {
+      this.destroy();
+      return;
+    }
+
+    this.physics.overlap(player, this, () => {
+      SaveManager.setFlag(this.flag, true);
+      SaveManager.saveAuto();
+      this.destroy();
+    });
+  }
+}

--- a/src/scenes/Play.ts
+++ b/src/scenes/Play.ts
@@ -2,6 +2,7 @@ import Phaser from 'phaser';
 import LDtkLoader from '../systems/LDtkLoader';
 import Player from '../entities/Player';
 import DialogueTrigger from '../entities/DialogueTrigger';
+import Pickup from '../entities/Pickup';
 import PhysicsAdapter from '../physics/PhysicsAdapter';
 import ArcadeAdapter from '../physics/ArcadeAdapter';
 import SaveManager, { GameSnapshot } from '../systems/SaveManager';
@@ -52,7 +53,8 @@ export default class Play extends Phaser.Scene {
         levelId: 'lvl_01',
         factories: {
           spawn: Player,
-          dialogue: DialogueTrigger
+          dialogue: DialogueTrigger,
+          pickup: Pickup
         }
       });
 
@@ -78,7 +80,10 @@ export default class Play extends Phaser.Scene {
       SaveManager.saveAuto();
 
       entities.forEach((e) => {
-        if (e instanceof DialogueTrigger && this.player) {
+        if (!this.player) return;
+        if (e instanceof DialogueTrigger) {
+          e.setup(this.player);
+        } else if (e instanceof Pickup) {
           e.setup(this.player);
         }
       });


### PR DESCRIPTION
## Summary
- add Pickup entity to grant double jump and persist via save flags
- spawn pickups from LDtk data in Play scene
- place double jump pickup in level 1 data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68983dff1f6883258de9eebdf8372e40