### PR TITLE
feat: add player gliding ability

### DIFF
--- a/src/entities/Pickup.ts
+++ b/src/entities/Pickup.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 import PhysicsAdapter from '../physics/PhysicsAdapter';
 import SaveManager from '../systems/SaveManager';
+import Player from './Player';
 
 export default class Pickup extends Phaser.GameObjects.Zone {
   private physics: PhysicsAdapter;
@@ -35,6 +36,9 @@ export default class Pickup extends Phaser.GameObjects.Zone {
 
     this.physics.overlap(player, this, () => {
       SaveManager.setFlag(this.flag, true);
+      if (player instanceof Player) {
+        player.obtain(this.flag);
+      }
       SaveManager.saveAuto();
       this.destroy();
     });


### PR DESCRIPTION
## Summary
- enable player gliding when holding jump after acquiring ability
- track gliding ability in inventory and save data
- grant ability on pickup and persist via SaveManager

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build` (fails: vite Permission denied)


------
https://chatgpt.com/codex/tasks/task_e_6898428722648325bfe40f5bdccc9937