### PR TITLE
feat: add dash input event

### DIFF
--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -55,6 +55,9 @@ export default class Player extends Phaser.GameObjects.Sprite {
     this.input.on('drop', () => {
       this.tryDropThrough();
     });
+    this.input.on('dash', () => {
+      // hook for dash action
+    });
 
     const snap = SaveManager.getSnapshot();
     if (


### PR DESCRIPTION
## Summary
- add SHIFT-based dash key and mobile dash button
- expose `dashPressed` and emit `dash` event on press
- allow Player to listen for `dash`

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build` (fails: vite: Permission denied)


------
https://chatgpt.com/codex/tasks/task_e_689845cb8df48325b9ba6bd4afc7d228