### PR TITLE
feat: track player abilities in save data

### DIFF
--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -85,14 +85,23 @@ export default class Player extends Phaser.GameObjects.Sprite {
     const snap = SaveManager.getSnapshot();
     if (
       SaveManager.getFlag('double_jump') ||
-      snap.player.inventory.includes('double_jump')
+      snap.player.inventory.includes('double_jump') ||
+      snap.player.abilities?.includes('double_jump')
     ) {
       this.maxJumps = 2;
     }
-    if (SaveManager.getFlag('glide') || snap.player.inventory.includes('glide')) {
+    if (
+      SaveManager.getFlag('glide') ||
+      snap.player.inventory.includes('glide') ||
+      snap.player.abilities?.includes('glide')
+    ) {
       this.canGlide = true;
     }
-    if (SaveManager.getFlag('dash') || snap.player.inventory.includes('dash')) {
+    if (
+      SaveManager.getFlag('dash') ||
+      snap.player.inventory.includes('dash') ||
+      snap.player.abilities?.includes('dash')
+    ) {
       this.dashUnlocked = true;
     }
     this.jumpsRemaining = this.maxJumps;
@@ -180,11 +189,22 @@ export default class Player extends Phaser.GameObjects.Sprite {
   }
 
   getSnapshot() {
+    const abilities: string[] = [];
+    if (this.maxJumps > 1) {
+      abilities.push('double_jump');
+    }
+    if (this.canGlide) {
+      abilities.push('glide');
+    }
+    if (this.dashUnlocked) {
+      abilities.push('dash');
+    }
     return {
       x: this.x,
       y: this.y,
       hp: this.hp,
       inventory: [...this.inventory],
+      abilities,
       maxJumps: this.maxJumps
     };
   }
@@ -195,22 +215,31 @@ export default class Player extends Phaser.GameObjects.Sprite {
     hp: number;
     inventory: string[];
     maxJumps?: number;
+    abilities?: string[];
   }) {
     this.setPosition(snapshot.x, snapshot.y);
     this.hp = snapshot.hp;
     this.inventory = [...snapshot.inventory];
+    const abilities = snapshot.abilities ?? [];
     if (snapshot.maxJumps !== undefined) {
       this.maxJumps = snapshot.maxJumps;
     } else if (
       SaveManager.getFlag('double_jump') ||
+      abilities.includes('double_jump') ||
       snapshot.inventory.includes('double_jump')
     ) {
       this.maxJumps = 2;
     } else {
       this.maxJumps = 1;
     }
-    this.canGlide = SaveManager.getFlag('glide') || this.inventory.includes('glide');
-    this.dashUnlocked = SaveManager.getFlag('dash') || this.inventory.includes('dash');
+    this.canGlide =
+      SaveManager.getFlag('glide') ||
+      abilities.includes('glide') ||
+      this.inventory.includes('glide');
+    this.dashUnlocked =
+      SaveManager.getFlag('dash') ||
+      abilities.includes('dash') ||
+      this.inventory.includes('dash');
     this.jumpsRemaining = this.maxJumps;
   }
 

--- a/src/systems/SaveManager.ts
+++ b/src/systems/SaveManager.ts
@@ -3,6 +3,7 @@ export interface PlayerSnapshot {
   y: number;
   hp: number;
   inventory: string[];
+  abilities: string[];
   maxJumps: number;
 }
 
@@ -21,7 +22,7 @@ export default class SaveManager {
   private static current: GameSnapshot = {
     levelId: 'lvl_01',
     checkpointId: 'start',
-    player: { x: 0, y: 0, hp: 100, inventory: [], maxJumps: 1 },
+    player: { x: 0, y: 0, hp: 100, inventory: [], abilities: [], maxJumps: 1 },
     inkStateJson: null,
     flags: {}
   };


### PR DESCRIPTION
## Summary
- extend player snapshot data with an `abilities` array
- persist player abilities through `SaveManager` and `Player` snapshot logic
- honor saved abilities when instantiating the player

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68984a91ef948325b017a5347a45e928