### PR TITLE
Add collision layer color and LDtk metadata

### DIFF
--- a/assets/levels/world.ldtk
+++ b/assets/levels/world.ldtk
@@ -1,4 +1,6 @@
 {
+  "jsonVersion": "1.5.3",
+  "appBuildId": 48680,
   "identifier": "world",
   "levels": [
     {
@@ -30,7 +32,8 @@
         "intGridValues": [
           {
             "value": 1,
-            "identifier": "solid"
+            "identifier": "solid",
+            "color": "#ff0000"
           }
         ]
       },


### PR DESCRIPTION
## Summary
- add explicit color for Collision intGrid tile
- record LDtk 1.5.3 metadata (jsonVersion & appBuildId)

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node -e "fs=require('fs'); JSON.parse(fs.readFileSync('assets/levels/world.ldtk','utf8')); console.log('JSON valid')"`


------
https://chatgpt.com/codex/tasks/task_e_68986415df70832584727658ec66862a