### PR TITLE
Ensure all LDtk tilesets are exported

### DIFF
--- a/assets/levels/lvl_01.json
+++ b/assets/levels/lvl_01.json
@@ -732,18 +732,14 @@
       ],
       "tilesets": [
         {
-          "__cWid": 4,
-          "__cHei": 4,
-          "identifier": "tileset2",
           "uid": 41,
           "relPath": "../tilesets/wood.png",
-          "embedAtlas": null,
-          "pxWid": 64,
-          "pxHei": 64,
-          "tileGridSize": 16,
-          "spacing": 0,
-          "padding": 0,
-          "tags": []
+          "tileGridSize": 16
+        },
+        {
+          "uid": 43,
+          "relPath": null,
+          "tileGridSize": 16
         }
       ],
       "enums": [


### PR DESCRIPTION
## Summary
- include all LDtk tilesets in the exported level file with uid, path and grid size

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689880e9cfa48325811b532ba593eafe