### PR TITLE
Load tileset images referenced by LDtk projects

### DIFF
--- a/src/systems/ManifestLoader.ts
+++ b/src/systems/ManifestLoader.ts
@@ -12,6 +12,9 @@ interface Manifest {
 }
 
 interface LDtkProject {
+  defs?: {
+    tilesets?: { uid: number; relPath: string }[];
+  };
   levels?: { externalRelPath: string }[];
 }
 
@@ -49,6 +52,11 @@ export default class ManifestLoader {
               this.loader.json(levelKey, levelPath);
               this.queued.add(levelPath);
             }
+          });
+          data.defs?.tilesets?.forEach((ts) => {
+            const normalizedUrl =
+              '/' + (base + ts.relPath).replace(/^(\.\/|\/)/, '').replace(/\.\.\//g, '');
+            this.loader.image('ts_' + ts.uid, normalizedUrl);
           });
         });
       }


### PR DESCRIPTION
## Summary
- Preload LDtk tileset images by reading `defs.tilesets`
- Normalize tileset URLs when queuing images

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6898853bdbe08325b12bfd7bebe7341f